### PR TITLE
Updates after the first run-through

### DIFF
--- a/markdown/how.md
+++ b/markdown/how.md
@@ -12,9 +12,6 @@ In our previous setup, we used the Open edX native installation method, which w
 
 Additionally, we run a self-paced, interactive learning platform, meaning we provide the learners with access to complex, realistic distributed environments on demand where they can learn things by actually doing it and OpenStack Heat comes in handy.
 
-Using a Heat template, we can define an exactly reproducible, self-contained environment consisting of, say, ten servers in three networks connected with two routers and arbitrarily involved configurations for each server. 
-Heat also provides the ability to suspend an entire stack, and then resume it at a much later date in the exact same state, which makes our platform very cost-effective.
-
 While both the deployment of labs and the deployment of the Open edX infrastructure involve the use of Heat, their approaches are completely different.
 Although we have replaced the Heat-driven approach to deploy the platform with one that interacts with Kubernetes, we have not replaced the Heat-driven approach to deploy our interactive labs.
 
@@ -31,7 +28,7 @@ Within our cloud infrastructure, we had two options available for container orch
 ### Private registry
 <!-- Note -->
 
-We needed a container orchestration service that could accommodate custom-built Docker images, and thus we decided to utilize the private Docker registry provided by Magnum. The built-in Docker registry runs locally on each Kubernetes's worker nodes localhost. It does not require authentication, making it easy to publish and pull images without any configuration changes to Tutor.
+We needed a container orchestration service that could accommodate custom-built Docker images, and thus we decided to utilize the private Docker registry provided by Magnum. The built-in Docker registry runs locally on each Kubernetes's worker nodes localhost.
 
 The Docker registry supported by Magnum is just the official Docker registry image with the OpenStack Swift storage driver. When invoked by Magnum, it is Magnum that automatically populates the registry's storage configuration with the necessary parameters to match the Swift endpoint in the region it's running in. In our CI, we duplicate this for a locally-running registry instance, backed by the same storage parameters, that we push our images to. Once we do, any thus-registered image becomes available to our Magnum registries.
 
@@ -49,17 +46,16 @@ The template defines paramters how the cluster will be constructed.
 
 In our production environment, we have six node Kubernetes clusters, three control plane nodes, and three worker nodes.
 
-We deploy our cluster with Kubernetes version as v.1.21.10 on Fedora CoreOS 34 with Cinder CSI driver enabled.
- Openstack Cinder is a block storage service that allows you to create persistent volumes for your Kubernetes cluster. By enabling the Cinder CSI driver on your Magnum cluster, you can create persistent volumes backed by Cinder block storage.
+We deploy our cluster with Cinder CSI driver enabled. So that we can create persistent volumes for our Kubernetes cluster backed by Cinder block storage.
 
-Octavia is the OpenStack load balancing service. We create a Kubernetes cluster with Magnum and use an Octavia Load Balancer to access it from the public network, via the the load balancer’s floating IP.
+And, we use Octavia (OpenStack load balancing service) to expose our Kubernetes cluster to the outside world via LoadBlancer type service.
 
 
 ## Ceph <!-- .element class="hidden" -->
 ![Ceph logo](images/ceph-logo.svg)
 <!-- Note -->
 
-To achieve automatic replication between the primary and DR site, we use Backup and Restore policy using the Ceph object gateway S3 API. We don't use the multi-site replication as provided by Ceph natively.
+We use the Ceph object gateway S3 API to achieve automatic replication between the primary and DR site. We don't use the multi-site replication as provided by Ceph natively.
 
 In our Kubernetes environment, the backup and restore process is implemented using cron jobs.
 

--- a/markdown/issues.md
+++ b/markdown/issues.md
@@ -5,14 +5,16 @@
 
 <!-- Note -->
 
-Recently, we experienced a temporary loss of control and compute nodes in one of our regions within our Cloud infrastructure. The region had our learning platform's primary(active) site. That incident led to not only the unavailability of Kubernetes nodes but also the loss of all load balancers and also the API service, which are both behind Octavia.
+In a recent incident, we lost access to our learning platforms. It was because the region in our cloud infra where we host our learning platform primary site had a meltdown and we had a temporary loss of control and compute nodes. This incident led to the unavailability of Kubernetes nodes and the loss of all load balancers and the Kubernetes API service, which are load-balanced behind Octavia.
 
-Although we had a disaster recovery setup in another region, we couldn't initiate failover because the Kubernetes API services, load-balanced by Octavia, were inaccessible. As a result, we were unable to access the cluster or execute any commands, hindering the Primary/DR switch that required running scripts against the Kubernetes cluster. This incident exposed our lack of preparedness for such an outage, highlighting flaws in our failover process. None of our systems will function until Octavia is fixed.
+So we lost accessibility to services that expose our Open edX platforms which are load-balanced behind Octavia, and also the Kubernetes API service. As a result, we can't execute any commands against the cluster. Therefore we can't initiate failover to our disaster recovery site as it requires some scripts to run against the cluster.
 
-Unfortunately, Octavia is always addressed last, as its functionality depends on the proper functioning of Nova and Neutron. Therefore, after a complete site failure, the controllers, Nova and Neutron, must be restored before investigating and fixing Octavia and the broken load balancers.
+This incident highlighted flaws in our DR policy and our failover process. Our systems will only work once Octavia is fixed. And Octavia always gets fixed last, and there's no way around that: for Octavia to work, Nova and Neutron must work, and so that means after a complete site meltdown, you must always get controllers up, and then Nova and Neutron, and only then can you look into fixing Octavia and broken load balancers. 
 
-Even after these issues are solved and we can communicate  with the Octavia API, often the loadbalancers are stuck in an ERROR state, which we can't fix it on 
-our own and need admin privileges to fix.
+Even after these issues are solved and we can communicate with the Octavia API, the load balancers are often stuck in an ERROR state, which we can't fix on our own.
+We have to wait for someone with admin privileges to fix it, which adds up to our downtime.
+
+To mitigate the downtime during the outage, we reconsidered our DR policy and looked for an alternative solution to expose our Open edX platform services other than the load balancer. For background, We use Caddy as a web server as Tutor uses it as a web proxy and for generating SSL/TLS certificates at runtime.
 
 
 ### Solutions?
@@ -21,27 +23,21 @@ our own and need admin privileges to fix.
 
 `NodePort`
 
-`LoadBalancer` with `externalIPs`
+`ClusterIP` with `externalIPs`
 
 <!-- Note -->
-To mitigate such downtime during outages, we explored an alternative solution to expose our Kubernetes service without relying on Octavia.
-We use Caddy as a web server as it is used in Tutor both as a web proxy and for generating SSL/TLS certificates at runtime.
 
-We were looking for a solution to expose the caddy service other than the loadbalancer and make our platform Octavia free. According to the Kubernetes documentation, several ways exist to expose a service in Kubernetes.
+We were looking for a solution to expose the caddy service besides the load balancer. As per the Kubernetes documentation, there are many ways to expose services other than the Loadbalancer type.
 
 * The first approach, ClusterIP, allows the service to be accessed only via an internal IP within the cluster. However, this type of exposure is not suitable for a production environment as it restricts accessibility within the cluster.
 
 * The second option, NodePort, is also unsuitable for our needs since our Caddy service operates on ports 80 and 443, while the NodePort range is from 30000 to 32767.
 
-* The third option is a loadbalancer, which we are trying to eliminate.
-* Lastly, there is a way not widely used among the kubernetes community because many are using cloud provider's Load balancers.
-Using ClusterIP with external IP
+* There is a way not widely used among the Kubernetes community because many use cloud providers' Load balancers which is using ClusterIP with external IP
+Customers can expose their Kubernetes cluster to external traffic using ClusterIP and an external IP address. This solution requires that the customer maps the external IP address of a service to their private IP addresses in the cluster.
+Unfortunately, we encountered issues in utilizing a Floating IP address as an external IP address. It was because our Floating IP address was getting mapped to a private address within a different subnet than the one used by the ClusterIP.
 
-Customers can expose their Kubernetes cluster to external traffic using ClusterIP and an external IP address. This solution requires that the customer maps the external IP address of a service to their private IP addresses in the cluster. 
-
-Unfortunately, we encountered issues in utilizing a Floating IP address as an external IP address. It was due to the fact that our Floating IP address was mapped to a private address within a different subnet than the one used by the ClusterIP.
-
-So, we were not able to figure out any way to expose our services without Loadbalancer. But we settled with an approach where rather than doing anything with the Kubernetes APIs, we would just operate on a single DNS record that we could flip, without using any API calls, to the backup site. That allows us to have at least a rudimentary service on the backup site, until load balancer functionality in the failed primary site becomes available again.
+We could not figure out any way to expose our services without Loadbalancer. But we settled with an approach where rather than doing anything with the Kubernetes APIs, we would operate on a single DNS record that we could flip, without using any API calls, to the backup site. That allows us to have a rudimentary service on the backup site until load balancer functionality in the failed primary site becomes available again.
 
 
 ## Orphaned Pods
@@ -65,9 +61,9 @@ We are facing this issue while performing a rolling update in our deployment.
 What happens in a rolling deployment?
 During a rolling deployment, the controller deletes and recreates pods with the updated configuration, one by one, without causing downtime to the cluster.
 
-However, our rolling deployment gets stuck when the pod running the old version remains in the Terminating state, and the new version that needs to be recreated gets stuck in the ContainerCreating state. This scenario is encountered with ReadWriteOnce access mode for Persistent Volumes. If we could use ReadWriteMany access mode,  we did not face this issue.
+However, our rolling deployment gets stuck when the pod with the mounted persistent volumes, running the old version remains in the Terminating state, and the new version that needs to be recreated gets stuck in the ContainerCreating state. This scenario is encountered with ReadWriteOnce access mode for Persistent Volumes. If we could use ReadWriteMany access mode,  we did not face this issue.
 
-When we check kubelet logs, we notice massive log entries stating "Orphaned pod found <pod UID>, but volumes are still present on the disk." So we dig deeper into the logs and see when the pod is getting deleted, it tries to unmount the CSI volumes. The unmount operation unmounts the volume, but fails to remove stale volume paths from the node.
+When we check kubelet logs, we notice massive log entries stating "Orphaned pod found <pod UID>, but volumes are still present on the disk." for the pods with mounted Persistent Volumes So we dig deeper into the logs and see when the pod is getting deleted, it tries to unmount the CSI volumes. The unmount operation unmounts the volume, but fails to remove stale volume paths from the node.
 
 This problem of pods getting stuck in the "Terminating" state due to the inability to clean volume subPath mounts is a known issue in Kubernetes. Several users have reported similar issues and there is no definite cause what arises the issue.
 

--- a/markdown/what.md
+++ b/markdown/what.md
@@ -112,6 +112,8 @@ Tutor aims to simplify the installation and upgrade process of Open edX platfor
 
 * Plugin System: Tutor uses a plugin-driven system that allows users to extend or customize Open edX without modifying the core codebase.
 
+* Kubernetes integration: Tutor comes with Kubernetes integration and facilitates running the Open edX platform on a Kubernetes cluster. Under the hood, Tutor wraps `kubectl` commands to interact with the cluster.
+
 Tutor provides comprehensive documentation that offers detailed information on how to use the distribution effectively. If you want to explore further, you can refer to the official Tutor documentation for more insights.
 
 


### PR DESCRIPTION
* Rewrite Loadbalancer Type services section.
* Tutor: Include Kubernetes integration
* OpenStack: Remove the explaination of heat template
* Private Registry: Remove confusing imformation regarding authentication
* Kubernetes: Remove information of Kubernetes and FCOS versions.
* Ceph: Rewrite to mention Ceph S3 API before mentioning Ceph replication
* Orphaned Pods: Include information of pods with PVs only getting stuck while rolling deployment