### PR TITLE
Some more slides (again)

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,6 +69,12 @@
                  data-separator-vertical="^\n\n"
                  data-separator-notes="<!-- Note -->">
 	</section>
+        <section id="questions"
+                 data-markdown="markdown/questions.md"
+                 data-separator="^\n\n\n"
+                 data-separator-vertical="^\n\n"
+                 data-separator-notes="<!-- Note -->">
+	</section>
       </div>
     </div>
 

--- a/markdown/questions.md
+++ b/markdown/questions.md
@@ -1,0 +1,53 @@
+<!-- .slide: data-timing="1" --> 
+# Backup slides for questions  <!-- .element class="hidden" -->
+
+<!-- Note -->
+This slide is intentionally blank.
+
+
+<!-- .slide: data-timing="1" --> 
+## Why S3 for Open edX,  
+## and not Swift?
+
+<!-- Note -->
+The Open edX platform does support both S3 and OpenStack Swift for object storage purposes (it uses [django-storages](https://django-storages.readthedocs.io/)), but its S3 support is much more mature and complete.
+
+So, since the Ceph Object Gateway gives us the option of running *both* APIs, we decided we'd go for the S3 API, because that just means a lot less work that we needed to do on the Open edX side of things.
+
+
+<!-- .slide: data-timing="1" --> 
+## Why not use HTTPS termination in Octavia?
+
+<!-- Note -->
+In principle we *could* terminate HTTPS in Octavia, rather than in Caddy like we do today.
+OCCM, that is the OpenStack Cloud Controller Manager, supports this through a service annotation.
+
+The way that works, it would look like this:
+
+
+<!-- .slide: data-timing="1" --> 
+### YAML example for service annotation <!-- .element class="hidden" -->
+
+```yaml
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: loadbalanced-service
+  annotations:
+    'loadbalancer.openstack.org/default-tls-container-ref': >
+       'https://example.com/path/to/barbican-secret'
+    'loadbalancer.openstack.org/x-forwarded-for': true
+spec:
+  type: LoadBalancer
+  # [...]
+```
+  
+<!-- Note -->
+We could use this, but it wouldn't work.
+That's because this way we can set the `X-Forwarded-For` HTTP header, but *not* `X-Forwarded-Port` which we also need, to make Open edX work.
+
+That in turn is because although the service annotation gives the option to set `X-Forwarded-For` (as you can see in the example), and *Octavia* also lets us set `X-Forwarded-Port`, we cannot combine the two for a `LoadBalancer` service with OCCM.
+
+We could work around this with a lot of manual hacking, but decided not to.
+That's why we terminate HTTPS with Caddy, and just use TCP load balancing through Octavia.


### PR DESCRIPTION
* Split a few more slides into several, in the section on issues. Makes for a better flow that way.
* For two potential questions that may arise, add backup slides to explain them in a little more detail. So as not to mess up the pacing timer calculation for the rest of the presentation, these slides are all set to take just 1 second out of the time budget. Also, insert one blank slide between the main part of the presentation and the backup slides, just so as not to advance to the question slides accidentally.

